### PR TITLE
Fix: Add "https:" protocol to jQuery href

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <meta name="keywords" content="Ilustrator,Vector,Vector Ruler, SVG, SVG ruler, Javascript SVG">
 <meta name="author" content="Robb Godshaw">
 <link rel="stylesheet" type="text/css" href="style.css">
-<script type='text/javascript' src='//ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js'></script>
+<script type='text/javascript' src='https://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js'></script>
 <script type="text/javascript" src="paper-full.js"></script>
 <script type="text/javascript" src="rulerGenerator.js"></script>
 


### PR DESCRIPTION
Fixes case of [running site locally from repo](https://github.com/Robbbb/VectorRuler/issues/7). jQuery is now fetched.