### PR TITLE
Fixes accessiblity Issues for Screen Reader Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 VectorRuler
 ===========
 [
-![Screenshot Of applet](AppletScreenshot.png?raw=true "Screenshot Of applet")](http://robbbb.github.io/VectorRuler/)
+![Screenshot Of applet, redirects to the running applet](AppletScreenshot.png?raw=true "Screenshot Of applet")](http://robbbb.github.io/VectorRuler/)
 
 A Javascript-based generator of laser cutter friendly etchable rulers
 ### Features

--- a/index.html
+++ b/index.html
@@ -23,7 +23,6 @@
         <span>Download a laser cuttable ruler to etch into your belongings and belts.</span>
     </h1>
     <form id="rulerParameters" action="" >
-
         <label>
             <span>Start:</span>
             <input type="text"  id="startNo"  value="0"  >
@@ -39,17 +38,22 @@
 
             <label>
                 <span>Units:</span>
-            </label>
+            
                 <Input type = "radio"  name="rulerUnits" value="inches" checked>
                     Inches
                     
                 <Input type = "radio"  name="rulerUnits" value="centimeters" >
                     Centimeters
+            </label>
                 <br>
+            <label>
+                <span>Sub Units:</span>
                 <Input type = "radio"  name= "subUnits" value = "2"   checked>
                     Fractional            
                 <Input type = "radio"  name= "subUnits" value = "10">
                     Decimal
+            </label>
+                <br>
             <label>
                 <span>Subdivisions: </span>
                 <select id="subUnitExponent"  style="width:30%" >
@@ -83,16 +87,6 @@
             <label>
                 <span></span>
             </label>
-			        			  <label>
-<span>Pixel per Inch: </span>
-				</label>
-	    
-	                    <Input type = "radio" name= "ppInch" value="96" checked>
-                    96 PPI - Most browsers and programs
-                    
-                <Input type = "radio"  name= "ppInch" value="72" >
-                    72 PPI - Adobe Illustrator
-                <br>
                 <input type="checkbox" name="redundant" id="redundant" >Draw redundant lines<br>
     </form>
     <form id="svgexpform" method="post" action="http://download-data-uri.appspot.com/" >

--- a/index.html
+++ b/index.html
@@ -84,9 +84,7 @@
 
                 </select>
             </label>
-            <label>
-                <span></span>
-            </label>            
+            <br>            
             <label>
                 <span>Pixel per Inch: </span>
                 <Input type = "radio" name= "ppInch" value="96" checked>

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
             <label>
                 <span></span>
             </label>
-                <input type="checkbox" name="redundant" id="redundant" >Draw redundant lines<br>
+                <input type="checkbox" name="redundant" aria-label="Draw redundant lines" id="redundant" >Draw redundant lines<br>
     </form>
     <form id="svgexpform" method="post" action="http://download-data-uri.appspot.com/" >
         <b>Filename: </b>

--- a/index.html
+++ b/index.html
@@ -86,16 +86,26 @@
             </label>
             <label>
                 <span></span>
+            </label>            
+            <label>
+                <span>Pixel per Inch: </span>
+                <Input type = "radio" name= "ppInch" value="96" checked>
+                    96 PPI - Most browsers and programs                            
+                <Input type = "radio"  name= "ppInch" value="72" >
+                    72 PPI - Adobe Illustrator
             </label>
-                <input type="checkbox" name="redundant" aria-label="Draw redundant lines" id="redundant" >Draw redundant lines<br>
+            <br>
+            <input type="checkbox" name="redundant" aria-label="Draw redundant lines" id="redundant" >Draw redundant lines<br>
     </form>
     <form id="svgexpform" method="post" action="http://download-data-uri.appspot.com/" >
-        <b>Filename: </b>
-        <input type="text" name="filename" value="exportedRuler.svg">
-        <input id="svgexpdata" name="data" value="123" type="hidden">
-        <a href="#" id="downloadSVG">
-            <input type="button" class="button" value="Download ruler as .SVG" id="svgexpbutton"> 
-        </a>
+        <label>
+            <span><b>Filename:</b></span>
+            <input type="text" name="filename" value="exportedRuler.svg">
+            <input id="svgexpdata" name="data" value="123" type="hidden">
+            <a href="#" id="downloadSVG">
+                <input type="button" class="button" value="Download ruler as .SVG" id="svgexpbutton"> 
+            </a>
+        </label>
     </form>
 
     <hr>


### PR DESCRIPTION
- [x] I confirm that all the content in this pull request is original work, and I am the original author
- [x] I have nothing that prevents me from submitting this work (like a clause in a work contract)
- [x] I understand that the work I am submitting will be released under the terms of the license of this repository
- [x] I have double-checked all of the above and checked the tick-boxes

My pull request attempts to resolve the following which should enable non-visual users to access the website as outline in issue #35 :
- Updates README to provide more descriptive alt text for link to web app
- Labels sub-unit radio buttons with a visual label
- Adds a non-visual label (aria-label) to redundant lines checkbox
- Fixes the Label for PPI so it is associated with the corresponding radio button input field
- Adds line break to left justify PPI radio buttons
